### PR TITLE
remove output files that are not needed for fv3 tests input

### DIFF
--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile1.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile1.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e7e3d1cd536e07166a5d3e05479bdb4a83955eefad832d7361cb886ca016ed5
-size 631840

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile2.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile2.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a113982bcc2ef3f1a92230c08c4e1b50c9fb6a3ca8c17d9751d4054b61a364b0
-size 631840

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile3.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile3.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:924572e1c8313e50e8ca25acc937f9cb0ff16a04bf360e365fa4a87aa7ea98c8
-size 631840

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile4.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile4.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d038680e83f3654b40fb4cfbda8ecbfb1b20bec599d5ede3f2186accd252788c
-size 631840

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile5.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile5.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3a43da5bcdce90e9a4236349062e28e4b9c9ab7e0b9528cc2115edd945d58884
-size 631840

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile6.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_core.res.tile6.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2bd18458919196fce7be994acf9c053f6ab2f49712dee4ceb5b3d0e41f56cf3
-size 631840

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile1.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile1.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42a833434d64717154c286d79b706eebbd8890b41b9c91c4941e1e4319caf6c4
-size 1336488

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile2.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile2.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa086ee4caea427c487ff4656cfed9a35bfd2741d3e334990f3133f9673452c2
-size 1336488

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile3.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile3.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a6718aaea5b36f52f53c7e57b8339a78102f230f42d1b09917ba448ea3d852e
-size 1336488

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile4.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile4.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cd4e1a478d7c8f35fbdda8d61a270d27041cd37869e4f547b71ecf1e5656134
-size 1336488

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile5.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile5.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38bd649dbaaaec78d70b76265ca952d24a0be874d5537dc1a2fc98ad3e63045b
-size 1336488

--- a/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile6.nc
+++ b/testinput_tier_1/inputs/gfs_c12/cold/20000101.000000.fv_tracer.res.tile6.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3809cffda3d74e2e1388b3a5fee92c441e321eec3214bb73fe487873dd87d398
-size 1336488


### PR DESCRIPTION
## Description

Removing output test files that were in this repo by mistake. 

### Issue(s) addressed

- fixes #5