### PR TITLE
Assimilation of derived variables

### DIFF
--- a/testinput_tier_1/obs/aircraft_obs_2018041500_m_renamed_var.nc4
+++ b/testinput_tier_1/obs/aircraft_obs_2018041500_m_renamed_var.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:443ab42f303bc7580529690fbd1e09f6036dd78928b3f051388d4f532fcb1c3c
+size 739235


### PR DESCRIPTION
## Description

This PR adds a copy of the aircraft_obs_2018041500_m.nc4 file in which the `air_temperature` variables in all groups are renamed to `renamed_air_temperature`. This is required by https://github.com/JCSDA-internal/fv3-jedi/pull/219.

### Issue(s) addressed

Contributes to JCSDA-internal/ufo#1187

## Dependencies

None

## Impact

None

## Test Data

None