### PR TITLE
Add new ghcn snow depth data for using totalSnowDepth as obs name.

### DIFF
--- a/testinput_tier_1/obs/ghcn_20191215_maskout.nc
+++ b/testinput_tier_1/obs/ghcn_20191215_maskout.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96fee0266b8056abe7094f317866092ac2ffb7abf35953471d20f3c4230d9f4a
-size 1043232
+oid sha256:f1495586cdcac3336f151388951a48b953ab234c0e654ce4f789eb1ecd9a7297
+size 1105739


### PR DESCRIPTION
## Description

*(Instructions: replace text in this and all sections with your own text)*

Provide a detailed description of what this PR does.
Provide the sample observation data to conduct snow DA by using the totalSnowDepth observation name. What I did is to replace the original data "ghcn_20191215_maskout.nc" with the new data in the ioda v2 format and using totalSnowDepth as observation variable name.

What problem does it fix? What new capability does it add?

[See the JEDI Documentation](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/pullrequest.html) for further information.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

If this does not close an existing issue, then [be sure to add a Pipeline, Label, Estimate, Assignees, and Epic](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/inside/practices/issues.html)

## Acceptance Criteria (Definition of Done)

What does it mean for this PR to be finished?

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- [ ] waiting on JCSDA/eckit/pull/<pr_number>
- [ ] waiting on JCSDA/atlas/pull/<pr_number>

## Impact

Please list the other repositories (if any) that this PR will require changes in (example below)

- [ ] saber
- [ ] ufo
- [ ] ...
