### PR TITLE
Remove unused observation files from fv3-jedi-data

### DIFF
--- a/testinput_tier_1/obs/2020100106_metars_small.nc
+++ b/testinput_tier_1/obs/2020100106_metars_small.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eea7f98fc518211ea0125d1759b743bf5af3a8836d0a606b2c95bbc8a92a72dc
-size 63403

--- a/testinput_tier_1/obs/Jason-2-2018-04-15.nc
+++ b/testinput_tier_1/obs/Jason-2-2018-04-15.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2db4de2f71aa73db174b2fd2e1005e4bc45950a627069dea19ef0d465152cf05
-size 2014845

--- a/testinput_tier_1/obs/abi_g16_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/abi_g16_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f0a3ddb16a029e61d1bb02ea97cf30499528343fd8aa9dd7cec50133c5e5d0f
-size 77599

--- a/testinput_tier_1/obs/abi_g16_obs_2019042306_m.nc4
+++ b/testinput_tier_1/obs/abi_g16_obs_2019042306_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20fbef579b9f7d0c664c13648e2a98a5d28bd5efb0016982fac66944dd02266a
-size 103444

--- a/testinput_tier_1/obs/abi_g16_obs_2019042306_s.nc4
+++ b/testinput_tier_1/obs/abi_g16_obs_2019042306_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:958eb13a3d06a25841a0b09ebfdc54f251bfca4ba03b41b74f9cdc528e8731c7
-size 85372

--- a/testinput_tier_1/obs/ahi_himawari8_obs_2019042306_m.nc4
+++ b/testinput_tier_1/obs/ahi_himawari8_obs_2019042306_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7dbedfd202b49a0772927ca728b3137f072277d585305e42995bff8d72f3eeb
-size 102948

--- a/testinput_tier_1/obs/ahi_himawari8_obs_2019042306_s.nc4
+++ b/testinput_tier_1/obs/ahi_himawari8_obs_2019042306_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97402f1280de9e3c81da62d802bce92046cd04778689bafdaf32c5f0d0ff3f42
-size 85381

--- a/testinput_tier_1/obs/aircraft_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/aircraft_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91fb34a3c2c457ffd35b33af5b1a53c44ebb68a7c24a4d1007ffd231b5cb2800
-size 165801

--- a/testinput_tier_1/obs/airs_aqua_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/airs_aqua_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94c2398c5f7c44620779155c2507147a520508f265b3486e39394e3d2288976b
-size 1118332

--- a/testinput_tier_1/obs/airs_aqua_obs_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/obs/airs_aqua_obs_2018041500_m_unittest.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:088845d1fbee545f17741978c5e0a15337cd11e1a67fef54f9f26ddd07dff646
-size 212385

--- a/testinput_tier_1/obs/amsua_aqua_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/amsua_aqua_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20bd22ab867c4a50b7fae590a9bc61ab6e6eba8df48cf52b313dbbf938c47c68
-size 113310

--- a/testinput_tier_1/obs/amsua_n19_obs_2018041500_m_miss_val.nc4
+++ b/testinput_tier_1/obs/amsua_n19_obs_2018041500_m_miss_val.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d58a1564f70d2fe64b08ed18febc7b2297dfc61b894bee37fa0c8d5b7b187381
-size 117268

--- a/testinput_tier_1/obs/amsua_n19_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/amsua_n19_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:483fdf65e8c3083fc8aeccb7a2fc2ff1423d4b9a98033ab5b454f1ac1618cb82
-size 302009

--- a/testinput_tier_1/obs/amsua_n19_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/amsua_n19_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32a88d63513997ac26000f7eb7124e6afe2d50c819e504c8bc1a44955f29818e
-size 292851

--- a/testinput_tier_1/obs/amsua_n19_obs_2018041500_s_qc.nc4
+++ b/testinput_tier_1/obs/amsua_n19_obs_2018041500_s_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d46915a647a10ed1cf51891f42448709135e43cc4475b4f20162afdd39d1bb7d
-size 204618

--- a/testinput_tier_1/obs/aod_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/aod_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:425b23adc21dd4a6dc4e5c8db84e847ba3b288fabb5ed9d7ea64cafae181eff3
-size 53134

--- a/testinput_tier_1/obs/aod_viirs_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/aod_viirs_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8cbcd2c6de092db9b4e798bcf6c3c4f6803ca1fcac700a4f1e3e5d5f95ebf73
-size 62492

--- a/testinput_tier_1/obs/aod_viirs_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/aod_viirs_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2418c384582d10f755f778753502f5a21aa849ceb0b1fb7b92edf4ac26504915
-size 60392

--- a/testinput_tier_1/obs/atms_n20_obs_20191230T0000_rttov.nc4
+++ b/testinput_tier_1/obs/atms_n20_obs_20191230T0000_rttov.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:313a23ec20b9d2f63f294f985b63a53ec44e5b156368263e9352efe1d28d6bc0
-size 93423

--- a/testinput_tier_1/obs/atms_npp_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/atms_npp_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2caa6dbda4a6fb4d6d250ba95ee0ddbab752a3d9d63f3d59292f3bae52b3080
-size 284518

--- a/testinput_tier_1/obs/atms_npp_obs_2018041500_m_qc_out_0000.nc4
+++ b/testinput_tier_1/obs/atms_npp_obs_2018041500_m_qc_out_0000.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bba149fe4fcb80b87f8424afe06af73aa1d8e6cc4d5febdd68198a1fb6fc1f90
-size 357265

--- a/testinput_tier_1/obs/atms_npp_obs_2018041500_s_qc.nc4
+++ b/testinput_tier_1/obs/atms_npp_obs_2018041500_s_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebd4328b725265ab2ba5ae11277401e3a0f6bba8171482a45a4b604377723022
-size 168558

--- a/testinput_tier_1/obs/coolskin_fake_obs_2018041500.nc
+++ b/testinput_tier_1/obs/coolskin_fake_obs_2018041500.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cc2a2a520568c5bc313aa39d1f5e72fc3a3f92e63416085d11bff9c07e10422
-size 26074

--- a/testinput_tier_1/obs/cris-fsr_npp_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/cris-fsr_npp_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f5f96e2d57c02c18e085bda500782354d7ebf50b76ece3f2e3967d35f1d6c6e
-size 1319766

--- a/testinput_tier_1/obs/cris-fsr_npp_obs_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/obs/cris-fsr_npp_obs_2018041500_m_unittest.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71250c4813481101b1170152440bfc69948e6b9d674353712b35c9e2ede242cb
-size 251071

--- a/testinput_tier_1/obs/cryosat2-2018-04-15.nc
+++ b/testinput_tier_1/obs/cryosat2-2018-04-15.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a63e610858c0a721c48165673d90864aedd701b08afe55c0e182bbc2420adb3
-size 137216

--- a/testinput_tier_1/obs/fileio.nc4
+++ b/testinput_tier_1/obs/fileio.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47595dea60b2ef1bbdff2984e373f90a8bb5b83417ba31e28c89821837e56440
-size 22548

--- a/testinput_tier_1/obs/ghcn_20191215_maskout_ER.nc
+++ b/testinput_tier_1/obs/ghcn_20191215_maskout_ER.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80e59fe88675098693a9c9fe49d727f3f5cecad725587e7e50de9c6057e95823
-size 16702

--- a/testinput_tier_1/obs/ghcn_20191215_maskout_WA.nc
+++ b/testinput_tier_1/obs/ghcn_20191215_maskout_WA.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f972d2342305a1bf55bd0b8fec322a046c7f1d1ef20ffcf895594d565f26e5e
-size 16702

--- a/testinput_tier_1/obs/gmi_gpm_obs_2020111500.nc4
+++ b/testinput_tier_1/obs/gmi_gpm_obs_2020111500.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9c5584856420c0ef71426d016f50d559a0311d0252e45f439bb80b9c3a27d85
-size 1221004

--- a/testinput_tier_1/obs/gnssro_obs_2018041500_1obs_bending_angle.nc4
+++ b/testinput_tier_1/obs/gnssro_obs_2018041500_1obs_bending_angle.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b84ef2d21ae084cd356a32a98aa23465eedfee969b0e21a69de8cb6a7d597389
-size 68202

--- a/testinput_tier_1/obs/gnssro_obs_2018041500_3prof.nc4
+++ b/testinput_tier_1/obs/gnssro_obs_2018041500_3prof.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b97016a0c7cde858bdce46f09d5a003ccbc89ef877fe091c2cc404de4487f9e0
-size 73240

--- a/testinput_tier_1/obs/gnssro_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/gnssro_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ed2168c60723e3680bcac7be3b2a52f76f7c664e8492bb3f78f8a61c84de780
-size 47387

--- a/testinput_tier_1/obs/gnssro_obs_2019050700_1obs.nc4
+++ b/testinput_tier_1/obs/gnssro_obs_2019050700_1obs.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e360dfaa85b4a655abebe32134892f1176af3a42933996f0385a27b4eee21c20
-size 46858

--- a/testinput_tier_1/obs/gnssro_obs_2020050106_1dvar.nc4
+++ b/testinput_tier_1/obs/gnssro_obs_2020050106_1dvar.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:709b9f5e38ce1e29349dacb4105857c941ec6ebf41f8b4e113781668a6befcf5
-size 51543

--- a/testinput_tier_1/obs/gnssro_obs_2020050106_nopseudo.nc4
+++ b/testinput_tier_1/obs/gnssro_obs_2020050106_nopseudo.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3baf62f5e448936312299c36e31362ef9f62275ba380e66b5ae458bdf852ba3
-size 46796

--- a/testinput_tier_1/obs/gome_metop-a_obs_2019101700_m.nc4
+++ b/testinput_tier_1/obs/gome_metop-a_obs_2019101700_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b10519f315f28d35cfb95f98c01ce76f67fa11159b43ec829a738742069ef5ee
-size 61886

--- a/testinput_tier_1/obs/gome_metop-a_obs_2019101700_s.nc4
+++ b/testinput_tier_1/obs/gome_metop-a_obs_2019101700_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d304263022fc10bdfa4d7c1f5e6b6c3958d2b717086c52cdf11ca4a24b3bedd9
-size 54981

--- a/testinput_tier_1/obs/groundgnss_obs_2019123006_obs.nc
+++ b/testinput_tier_1/obs/groundgnss_obs_2019123006_obs.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee04623f3f22bc6b9f9476e531c7cda00904b6d54ed161b22506b4f4d8a75477
-size 20394

--- a/testinput_tier_1/obs/gsisfc_tsen_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/gsisfc_tsen_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:549eb680b2037411427697dd163de4920f2016363f1fffb1f30ec74cdb6e3cdc
-size 60220

--- a/testinput_tier_1/obs/gsisfc_uv_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/gsisfc_uv_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e5d0a020a85bf850ea7b8cfea382e03ea99ab9ace17af32c3b19a6bf5121715
-size 92408

--- a/testinput_tier_1/obs/hirs4_metop-b_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/hirs4_metop-b_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:479f243bfa803f34a19ceff2f1caf53b84f75e8e2ba80d0c6877d048481b912c
-size 121649

--- a/testinput_tier_1/obs/iasi_metop-a_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/iasi_metop-a_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cd3d4f5aa65d34d6c29714fd8ac199971269c2ce065c9355b7f19202246dd49
-size 2355060

--- a/testinput_tier_1/obs/iasi_metop-a_obs_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/obs/iasi_metop-a_obs_2018041500_m_unittest.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9ba0eac68a4cf04a3d45751659c567736bb256d8a2ebcc23d4afc21ad26317d
-size 335434

--- a/testinput_tier_1/obs/iasi_metop-b_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/iasi_metop-b_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c648a15be1cc637db356184ab03d5c67c70f7ba8244027f229d4e54a7941c526
-size 2339554

--- a/testinput_tier_1/obs/iasi_metop-b_obs_2018041500_m_unittest.nc4
+++ b/testinput_tier_1/obs/iasi_metop-b_obs_2018041500_m_unittest.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c44aa368780fedb7ca7ec11a61971fae4546b6e7a53c89bcbcfb9d3cfa66215c
-size 349286

--- a/testinput_tier_1/obs/icec-2018-04-15.nc
+++ b/testinput_tier_1/obs/icec-2018-04-15.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0755edd0caf203544336e1904c1d5a67b6107177af7fad88024a1ca83948d13
-size 94521

--- a/testinput_tier_1/obs/instruments/conventional/aircraft_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/aircraft_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fef58246cdc3b7c47e53731a44c4237a68f1a8107f33639643ae4b48b2410cb8
-size 216858

--- a/testinput_tier_1/obs/instruments/conventional/rass_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/rass_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf48c1e5976feb0fd892b1b301429278e890c2ea2f9308aa4855222bca42ff41
-size 65908

--- a/testinput_tier_1/obs/instruments/conventional/satwind_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/satwind_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f880e424813c679a9c038984bf1409234db34aada912ca55d82ee43a142a11d
-size 114935

--- a/testinput_tier_1/obs/instruments/conventional/scatwind_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/scatwind_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:31a274bc2e3da0d61f8edde3878e1ce5cf588da1eb8801a82d3fb9db7fe9474d
-size 102400

--- a/testinput_tier_1/obs/instruments/conventional/sfc_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/sfc_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1251bbca318daba69759b70b157b5acf84030727835903aca7952f2bddcd5bf5
-size 248316

--- a/testinput_tier_1/obs/instruments/conventional/sfcship_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/sfcship_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c48bb1fbfbc7475e3645635411ad522e2fc7db3342dcf92018b331863da1b9c1
-size 224263

--- a/testinput_tier_1/obs/instruments/conventional/sondes_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/sondes_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f770276fdef84ee9744e43efe376c42a505da041b1aca4516fa325407bcc420f
-size 421617

--- a/testinput_tier_1/obs/instruments/conventional/vadwind_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/conventional/vadwind_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ea4549772e56a16634a7bbb49db20b3a9a7fea7f1b907f4268f5fc0b3ea26c9
-size 173293

--- a/testinput_tier_1/obs/instruments/radiance/airs_aqua_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/airs_aqua_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db91c80cb523af057e70863674196e3a2a997cf98d00e9267d9c95355a9e5d4b
-size 288246

--- a/testinput_tier_1/obs/instruments/radiance/amsua_aqua_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_aqua_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d87acda0a063b3848348a429471e4aa612830989f1490bbd1ce3bf7e1d04e948
-size 174145

--- a/testinput_tier_1/obs/instruments/radiance/amsua_metop-a_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_metop-a_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bb198506b347170e752ddc8954922588aa12b83090d284ebef67ee812c50471
-size 177082

--- a/testinput_tier_1/obs/instruments/radiance/amsua_metop-b_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_metop-b_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3afd63e46346b8d9967f095641eae650103a2bc993a1c5e5ff4d9d9e10175c74
-size 175148

--- a/testinput_tier_1/obs/instruments/radiance/amsua_metop-c_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_metop-c_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e99c608a63b1bd64c5c0babc92cb1de9684abd88d299943764c56f6cc4e4dcbb
-size 176754

--- a/testinput_tier_1/obs/instruments/radiance/amsua_n15_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_n15_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3f57341605575c97686e133076f1f5180f8a4580a442433a617585166cc842f
-size 176536

--- a/testinput_tier_1/obs/instruments/radiance/amsua_n18_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_n18_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7353e385b4f730c169a95bde94d001bf198de1a86af903a23f4094cf238a0ed
-size 176748

--- a/testinput_tier_1/obs/instruments/radiance/amsua_n19_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/amsua_n19_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac090975da3bee717cff5fbc75e9ce095226f8e47766f1c4042b1564dadc9847
-size 176145

--- a/testinput_tier_1/obs/instruments/radiance/atms_n20_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/atms_n20_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2973673b884a275a157b0831d232bb939cc22342a18bd1689936278882ae5264
-size 180791

--- a/testinput_tier_1/obs/instruments/radiance/atms_npp_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/atms_npp_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de89aa877e4141513d1dfd7043e3f94ef91e9d1aaa9ccf56a3dd2fef37441fee
-size 181098

--- a/testinput_tier_1/obs/instruments/radiance/avhrr_n18_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/avhrr_n18_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:51c5658b6f17895ee087ea11c5369df63bb93095829f3a280e08c8584648abe8
-size 81859

--- a/testinput_tier_1/obs/instruments/radiance/cris-fsr_n20_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/cris-fsr_n20_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65d6ae5e1e3b3254b6be114bc18ea828b5d1d3e86851894df98330f9cae8a5f2
-size 315933

--- a/testinput_tier_1/obs/instruments/radiance/cris-fsr_npp_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/cris-fsr_npp_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a63482348a4eab0bad5835dbcef5dcb725a2d90c39a43fc6c6d37c860ba6dd6c
-size 329125

--- a/testinput_tier_1/obs/instruments/radiance/iasi_metop-a_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/iasi_metop-a_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b9c1d0a5d518cdce68c67a096e8b7878432c536836b1546b4f62b7bf78595d9
-size 463034

--- a/testinput_tier_1/obs/instruments/radiance/iasi_metop-b_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/iasi_metop-b_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a27fa5ce0540dffb324b27f624db5ec79b4acfc3c55e04620fad619fff59f1b
-size 420039

--- a/testinput_tier_1/obs/instruments/radiance/mhs_metop-b_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/mhs_metop-b_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7429d5abc0c21d6683a7bc86f692422f6456735a09660ead10c4de81e4858a3
-size 81861

--- a/testinput_tier_1/obs/instruments/radiance/mhs_metop-c_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/mhs_metop-c_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5049d819e2685d00013a4ae2eabb403854f6e69c3f2a14437fdc276fdbf5d751
-size 81861

--- a/testinput_tier_1/obs/instruments/radiance/mhs_n19_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/mhs_n19_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b88076cc8f364e6bc510218f19c1ce64b5156a234c1a848504b2edb9ef48197b
-size 81857

--- a/testinput_tier_1/obs/instruments/radiance/seviri_m11_obs_2020110112_m.nc4
+++ b/testinput_tier_1/obs/instruments/radiance/seviri_m11_obs_2020110112_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:562d54d05de316e9346f3a2f4ae03fe53bc551203b5e472fcf6b9f131dd479ec
-size 81986

--- a/testinput_tier_1/obs/ioda_metop_2_amsua.nc4
+++ b/testinput_tier_1/obs/ioda_metop_2_amsua.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3a059149e354602ff16fb6399a0f018d84ee4a5d5c94cec302d527d6591179a3
-size 40602

--- a/testinput_tier_1/obs/ioda_test_descending_sort.nc4
+++ b/testinput_tier_1/obs/ioda_test_descending_sort.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5e4f98820dd67e6ca941efcf739327fe6b10db5ba94002f044fbfd2e1c4037b
-size 19953

--- a/testinput_tier_1/obs/met_office_conversion_height2pressure.nc4
+++ b/testinput_tier_1/obs/met_office_conversion_height2pressure.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:947eb950223c9d2e985c47c1792c02fe7f1ff4f51d7620892715a2ec3863e329
-size 523592

--- a/testinput_tier_1/obs/met_office_profile_consistency_checks_sondeflags.nc4
+++ b/testinput_tier_1/obs/met_office_profile_consistency_checks_sondeflags.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2bf9f7ee5953258bffb9c34df20e497308dd5e78bb4c88c45ec92b1cb4e47f2f
-size 165547

--- a/testinput_tier_1/obs/met_office_profile_consistency_checks_winproflags.nc4
+++ b/testinput_tier_1/obs/met_office_profile_consistency_checks_winproflags.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39867c501b3080c0cfdf943f0840f1b2541787f2a2dfd3857db8c2bd3422bec5
-size 150294

--- a/testinput_tier_1/obs/mhs_n19_obs_2018041500_m_qc.nc4
+++ b/testinput_tier_1/obs/mhs_n19_obs_2018041500_m_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebf666ef6a2f63cf1c28b02d0774b315ef69a09ea3f86e62a0dc5cc25dfbd54e
-size 87264

--- a/testinput_tier_1/obs/multichannel_variable_assignment_testdata.nc
+++ b/testinput_tier_1/obs/multichannel_variable_assignment_testdata.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10af526e1cfabdbdf2a9064016255aab530e8ff2ff97d454ff4bf507c1a3e163
-size 8268

--- a/testinput_tier_1/obs/nnr_aod_2ch_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/nnr_aod_2ch_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49bef16e74cb0c0d4e2a801b072dae71f2e5f61b90e0cb45f4a5998d0faec266
-size 47805

--- a/testinput_tier_1/obs/nnr_aod_3ch_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/nnr_aod_3ch_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2917ffbed9cd14edf211d282f95cae4fbb5540c1d0fb69dd5136090fa7219763
-size 49053

--- a/testinput_tier_1/obs/obsspace_grouping.nc4
+++ b/testinput_tier_1/obs/obsspace_grouping.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b04c698ada585305e5c948a7d717baa72129754fb654160adfb23dc61e46f6c
-size 22768

--- a/testinput_tier_1/obs/obsspace_index_recnum.nc4
+++ b/testinput_tier_1/obs/obsspace_index_recnum.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f6937f186a8b684fbf4846fa4d51caf42a30972317621c5f5164b86e021080c
-size 16528

--- a/testinput_tier_1/obs/omi_aura_obs_2019101700_m.nc4
+++ b/testinput_tier_1/obs/omi_aura_obs_2019101700_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14c01dc23a20ba1038dc64c8531c6b4854452b4cf000d1ee131dd03819d83488
-size 61794

--- a/testinput_tier_1/obs/omi_aura_obs_2019101700_s.nc4
+++ b/testinput_tier_1/obs/omi_aura_obs_2019101700_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0b2b1e6a3fd77cedca5c7240ce146a69252039781bf4543529f647e1d32de54
-size 54974

--- a/testinput_tier_1/obs/ompslp_npp_obs_2019101700.nc4
+++ b/testinput_tier_1/obs/ompslp_npp_obs_2019101700.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c90c36ab7ad5b9269ec2b181207923b97109dd8a6810b53720732bb11716953
-size 617303

--- a/testinput_tier_1/obs/ompslp_npp_obs_2019101700_m.nc4
+++ b/testinput_tier_1/obs/ompslp_npp_obs_2019101700_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:367d3950f7a5c60cf0863f4eff83d5879b5f65871f7c48b005f4e9ec4fc37ff0
-size 47939

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2019101700_m.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2019101700_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7674669794c6b1950c1aecd59b7cd79cc9aa9c6838c93a121fe16d0148ac7e5c
-size 150802

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2019101700_s.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2019101700_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c071f5384e63ae003c370ccca22085455e237be3d96f2f4b4efacdd1bcbd2992
-size 54977

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_m.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6658a9e8fad6459793e7906561d11f609c2fd03aa324e019fc791fe06a0e1c88
-size 146365

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_qc.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_qc.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b01e6e644cdd2b6dc3f6bda5b9da46c964e5072906582c03a6c035a05371743b
-size 492253

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_qc_m.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_qc_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bed9c742af4c5ea88a0c008868ab6874ca636b9e0772ff8ec06b997f1f29ef3f
-size 158807

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_qc_s.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_qc_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bed9c742af4c5ea88a0c008868ab6874ca636b9e0772ff8ec06b997f1f29ef3f
-size 158807

--- a/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_s.nc4
+++ b/testinput_tier_1/obs/ompsnp_npp_obs_2020051712_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8200bacdfae2b08c35ce8ce07bbb9a8986cb57421eb7876d47e9cc616f125b53
-size 146365

--- a/testinput_tier_1/obs/ompstc8_npp_obs_2019101700_m.nc4
+++ b/testinput_tier_1/obs/ompstc8_npp_obs_2019101700_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee2122c0669d46709bffd3828d65e887430ef73e57c3b4fbb6599eee8409074f
-size 61430

--- a/testinput_tier_1/obs/ompstc8_npp_obs_2019101700_s.nc4
+++ b/testinput_tier_1/obs/ompstc8_npp_obs_2019101700_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2176c395c7285b90d9f3aef8bdc39d8b555e6aeddd896b8c85ffecd1e73c41c9
-size 54978

--- a/testinput_tier_1/obs/profile_2018-04-15.nc
+++ b/testinput_tier_1/obs/profile_2018-04-15.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee525af50a371f1530073b8908525e0797f3c86852b0e9e7ab7e043bbeac375c
-size 26408

--- a/testinput_tier_1/obs/radar_dbz_obs_2019052222.nc4
+++ b/testinput_tier_1/obs/radar_dbz_obs_2019052222.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97568117106467043cf15675e79e8cd8a3617a29c055c3727a8c56156fa9b661
-size 795496

--- a/testinput_tier_1/obs/radar_rw_obs_2019052222.nc4
+++ b/testinput_tier_1/obs/radar_rw_obs_2019052222.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77b3bbf5cc4e006041517fa35a3591a896b1fdc3a5808cb5f901ba0f6e7d8623
-size 53352

--- a/testinput_tier_1/obs/radar_rw_obs_2020101300_m.nc4
+++ b/testinput_tier_1/obs/radar_rw_obs_2020101300_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5ccc17a27de290d58b6119f62c2c11240095d2ce29a446e0e828ca0fcf8d2d1
-size 84036

--- a/testinput_tier_1/obs/radar_rw_obs_2020101300_s.nc4
+++ b/testinput_tier_1/obs/radar_rw_obs_2020101300_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f92f4d8df0fc681d1d1bb2bb60abeb5456eb6e339a14540e19382cf4d6017b39
-size 72031

--- a/testinput_tier_1/obs/satwind_obs_1d_2020100106_noinv.nc4
+++ b/testinput_tier_1/obs/satwind_obs_1d_2020100106_noinv.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8aba9f6d42ee7bd5281487e6a24bd0fae1757f51b42704b4cc2cd5c514cc344f
-size 10097046

--- a/testinput_tier_1/obs/satwind_obs_2018041500_ms.nc4
+++ b/testinput_tier_1/obs/satwind_obs_2018041500_ms.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff7925ced49585a2d8c941721bf85070fc64afea0c02c95f743e0d0c97b0ba3b
-size 113000

--- a/testinput_tier_1/obs/satwind_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/satwind_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8250c9e4d4434a2666ba464f69aee793571f6707a613c37b88dac49372b2b5e5
-size 85927

--- a/testinput_tier_1/obs/satwind_obs_2d_2020100106_noinv.nc4
+++ b/testinput_tier_1/obs/satwind_obs_2d_2020100106_noinv.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcb5909b2837a065c86837a8100e81c43319a32135296f823f7c89b1f050f15e
-size 10093618

--- a/testinput_tier_1/obs/satwind_obs__1d_2020100106_noinv_out_ref.nc4
+++ b/testinput_tier_1/obs/satwind_obs__1d_2020100106_noinv_out_ref.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2db3febf0bf2a929a151457a19491c0a6692b41583643d93f385d35f427862c1
-size 13033450

--- a/testinput_tier_1/obs/sbuv2_n19_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/sbuv2_n19_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a82b1a2c8e69d3d7dcf149f01a077cff3e621e397e7d0c6ada79b178ca3ea1b
-size 155804

--- a/testinput_tier_1/obs/sbuv2_n19_obs_2019101700_m.nc4
+++ b/testinput_tier_1/obs/sbuv2_n19_obs_2019101700_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:606eb1fb2a5e33441c9451791b10b2f3bdc7afac05521ca8b6f79617b86c8d5d
-size 150743

--- a/testinput_tier_1/obs/sbuv2_n19_obs_2019101700_s.nc4
+++ b/testinput_tier_1/obs/sbuv2_n19_obs_2019101700_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93800b4d654406a1a38b433a4de012f34bf68426d6f869a921d5a65cedaf010a
-size 54976

--- a/testinput_tier_1/obs/sbuv2_n19_obs_2020051712_m.nc4
+++ b/testinput_tier_1/obs/sbuv2_n19_obs_2020051712_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1866281f357ee358104fdc52ffdc346fb5b1e057a1710b95c7f5358961c78af4
-size 154931

--- a/testinput_tier_1/obs/sbuv2_n19_obs_2020051712_s.nc4
+++ b/testinput_tier_1/obs/sbuv2_n19_obs_2020051712_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1866281f357ee358104fdc52ffdc346fb5b1e057a1710b95c7f5358961c78af4
-size 154931

--- a/testinput_tier_1/obs/scatwind_obs_1d_2020100106.nc4
+++ b/testinput_tier_1/obs/scatwind_obs_1d_2020100106.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a915b9742b2af59f2d5a50df603cc59a94a5a383f9a5604f649d98ab19a36d3
-size 1909793

--- a/testinput_tier_1/obs/scatwind_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/scatwind_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbce59522db3920a12bc689476063418c75f9c5f1ea53bf0feadb3e27ab20694
-size 85927

--- a/testinput_tier_1/obs/scatwind_obs_2d_2020100106.nc4
+++ b/testinput_tier_1/obs/scatwind_obs_2d_2020100106.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8afe296f8ea032507664e489137122e618202657ed16a3fa30573d15033ce4d1
-size 2479910

--- a/testinput_tier_1/obs/sfc_obs_2018041500_metars_small.nc
+++ b/testinput_tier_1/obs/sfc_obs_2018041500_metars_small.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12b5881653320af9f41c3b626a397277d6e6087d12c38a7b404046fa91d7a09b
-size 82468

--- a/testinput_tier_1/obs/sfc_obs_2018041500_metars_small2.nc
+++ b/testinput_tier_1/obs/sfc_obs_2018041500_metars_small2.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f2a9d35880e6e25bf04a9dd7e6cbed122758c2fa1a959aee7602b9c044f6c7c
-size 80880

--- a/testinput_tier_1/obs/sfc_obs_2018041500_new.nc4
+++ b/testinput_tier_1/obs/sfc_obs_2018041500_new.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:619c522e48e12c67552f683dc70d3a1d36c8ecc29be61b53db38318ca341f6d3
-size 239878

--- a/testinput_tier_1/obs/sfc_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/sfc_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed0b8b5b7903ab65ca43664749b9aacff42913fe8ad6bec16bfd37ccf90ee1b7
-size 199138

--- a/testinput_tier_1/obs/sfcship_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sfcship_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7db847d8427e04c41389bf126ea6f0e1b525ed596d4d62f1c8bd6a434d3634ff
-size 257715

--- a/testinput_tier_1/obs/sfcship_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/sfcship_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81d0203aa6f3026e4008e6559c4ccad113e4de482b1fa3475fd129ec7021da00
-size 203585

--- a/testinput_tier_1/obs/sfcship_synthetic_airtemp_m.nc4
+++ b/testinput_tier_1/obs/sfcship_synthetic_airtemp_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37236bd739e9799d2acd693cc8a0f6ca3f702557b0f92c16f3e4ff50b9a5517b
-size 259863

--- a/testinput_tier_1/obs/sndrd2_g15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sndrd2_g15_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52e5f21acaa0dc7a2a682ddba62dab1fc7a098154ece7816cf6524b14560e08c
+size 119210

--- a/testinput_tier_1/obs/sndrd2_g15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sndrd2_g15_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52e5f21acaa0dc7a2a682ddba62dab1fc7a098154ece7816cf6524b14560e08c
-size 119210

--- a/testinput_tier_1/obs/sndrd3_g15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sndrd3_g15_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72dd097359812ff64aa203655315b86c35dc37eb549cae901c321df47ecd5331
-size 119071

--- a/testinput_tier_1/obs/sndrd3_g15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sndrd3_g15_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72dd097359812ff64aa203655315b86c35dc37eb549cae901c321df47ecd5331
+size 119071

--- a/testinput_tier_1/obs/sndrd4_g15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sndrd4_g15_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3b2141ca03e779b4b0112d4c7388b05810ccb2d76463e811f012b0f94a931d1
-size 119276

--- a/testinput_tier_1/obs/sndrd4_g15_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sndrd4_g15_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3b2141ca03e779b4b0112d4c7388b05810ccb2d76463e811f012b0f94a931d1
+size 119276

--- a/testinput_tier_1/obs/sondes_obs_2018041500_m_twfilt.nc4
+++ b/testinput_tier_1/obs/sondes_obs_2018041500_m_twfilt.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef5a569f6008e5496551f21c41df13036a38b13b45f5b7a41dc466a68e5bb6dc
-size 306111

--- a/testinput_tier_1/obs/sondes_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/sondes_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36327ce1410488b7bb48cf39d1c0240bb1aa3b152839256d061272a8960b6f95
-size 181855

--- a/testinput_tier_1/obs/sondes_obs_2018041500_vs.nc4
+++ b/testinput_tier_1/obs/sondes_obs_2018041500_vs.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae2e6d68703643fc38ed9d17b1ba45f3c7aa62ec569d33f74496b597ac0c41bb
-size 169660

--- a/testinput_tier_1/obs/sondes_tv_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/sondes_tv_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7476be8b605ca253e399b9c8e86bb0dadd4303855a045a90f5f0413922cc720
-size 91868

--- a/testinput_tier_1/obs/sondes_tv_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/sondes_tv_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c02a777e034ce0da0afa1dbe192d31b176d8300ce9aac3a8b5c2125be45ec582
-size 59531

--- a/testinput_tier_1/obs/ssmis_f18_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/ssmis_f18_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf8b9b424749e662343d9f9ec7a27a10959c611f263a3bcb1343c426a3fa03dc
-size 128904

--- a/testinput_tier_1/obs/sst_obs-2018-04-15.nc4
+++ b/testinput_tier_1/obs/sst_obs-2018-04-15.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee44e35c41dc4aed9a8860be5276a0e973665c7e5a677573e625897020cbd2eb
+size 19993

--- a/testinput_tier_1/obs/sst_obs-2018-04-15.nc4
+++ b/testinput_tier_1/obs/sst_obs-2018-04-15.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee44e35c41dc4aed9a8860be5276a0e973665c7e5a677573e625897020cbd2eb
-size 19993

--- a/testinput_tier_1/obs/synthetic-adt-2018041500.nc
+++ b/testinput_tier_1/obs/synthetic-adt-2018041500.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a54ac638c9423194d65adbe4484a730577aecdfee9519b26e3e8dfe3aa0ed2e
-size 20521

--- a/testinput_tier_1/obs/vadwind_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/vadwind_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0403ad791b6240a077d411329c97f41e885aee4158a3feebd7714a54369354b
-size 207964

--- a/testinput_tier_1/obs/vadwind_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/vadwind_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47a8c9ee83c4846309dbf7686278e421cdd8092781c47f7b4f36ed70e8c31073
-size 104499

--- a/testinput_tier_1/obs/variable_assignment_testdata.nc
+++ b/testinput_tier_1/obs/variable_assignment_testdata.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:806bb45b6049a5c42fb0e58a4e7529b7dd4c4a59c1963a3f4b82748f932b86e5
-size 8268

--- a/testinput_tier_1/obs/viirs_jpss1_oc_l2_2018-04-15.nc
+++ b/testinput_tier_1/obs/viirs_jpss1_oc_l2_2018-04-15.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0aa239ca09667e624b098912bf79509b631fdaec1eff8d85c6b75d5a735d897
-size 26980

--- a/testinput_tier_1/obs/wind_unit_transforms_2018041500.nc4
+++ b/testinput_tier_1/obs/wind_unit_transforms_2018041500.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67c84168a4a4d895fd4cd01ad32d6142305a227b03846f8aec27c8e2234bf625
-size 129460

--- a/testinput_tier_1/obs/windprof_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/windprof_obs_2018041500_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:294e7fcba3f119687194b0dbcdcfe282d1cebf35a7136dc0d3dc65b53b3ef7a5
-size 94541

--- a/testinput_tier_1/obs/windprof_obs_2018041500_s.nc4
+++ b/testinput_tier_1/obs/windprof_obs_2018041500_s.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25e42d361b41c1282f4d5e529dff21ec43831b4901e9c244baace78dbda131fc
-size 85927


### PR DESCRIPTION
## Description

I realized many observations files aren't used at all (ie not even mentioned in any fv3-jedi test yaml file). These files are often used by ufo tests, but there is the ufo-data repository for that purpose. 
After discussion with @mer-a-o, we decided it would be good to clean up these files from fv3-jedi-data.
I made sure all the fv3-jedi tests still passed, and they aren't affected, as expected. 

This PR will be useful in preparation for moving to 127 levels in gfs tests (when we need to change a lot of the data, to get a new date).

tests ran in https://github.com/JCSDA-internal/fv3-jedi/pull/314

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #19 