### PR TITLE
adding links to crtm surface data for geos members

### DIFF
--- a/testinput_tier_1/inputs/geos_c12/geos.mem001.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem001.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem002.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem002.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem003.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem003.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem004.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem004.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem005.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem005.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem006.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem006.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem007.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem007.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem008.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem008.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem009.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem009.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4

--- a/testinput_tier_1/inputs/geos_c12/geos.mem010.crtmsrf.20201215_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.mem010.crtmsrf.20201215_000000z.nc4
@@ -1,0 +1,1 @@
+geos.bkg.crtmsrf.20201215_000000z.nc4


### PR DESCRIPTION
## Description
For lgetkf runs, we need to observe each member individually. Thank you @cmgas for adding a bunch of these data already. This PR adds some more missing data (via symlinks) to the crtm surface types for geos files. 

### Issue(s) addressed
- fixes #25 

## Acceptance Criteria (Definition of Done)
I have tested this in 
https://github.com/JCSDA-internal/fv3-jedi/pull/400

## Dependencies
This PR needs to be merged before 
https://github.com/JCSDA-internal/fv3-jedi/pull/400

## Impact
none