### PR TITLE
Adding viirs_bias.nc  file for aerosol bias correction DA.

### DIFF
--- a/testinput_tier_1/obs/VIIRS_bias.nc
+++ b/testinput_tier_1/obs/VIIRS_bias.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9dfe8776c8c23315c6f212925a19d6d67933d3be915b6df1b6286007b43851
+size 7928


### PR DESCRIPTION
This file (viirs_bias.nc)  is needed for the VIIRS aod bias correction, hyb-3dvar_gfs_aero_bc.yaml. It was not included in the previous PR, and the ctest will fail without it.


