### PR TITLE
sss obs added

### DIFF
--- a/testinput_tier_1/obs/sss_obs_20201215_m.nc4
+++ b/testinput_tier_1/obs/sss_obs_20201215_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dbc8444ba6dd80480473810349014df13a2258501dd1dba3a9512a5367bea68
+size 41759


### PR DESCRIPTION
## Description

I have added  the sss obs data for 20201215 using the SMAP SSS retrieval to be able to test sss again using the fv3-jedi/hofx_fv3-gfs.yaml test.

### Issue(s) addressed

- fixes #36 

