### PR TITLE
update data test data for cmaq and geos-cf tests

### DIFF
--- a/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20190102_000000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20190102_000000z.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:939af6289e6d5e9903243fb94ea317b0c086b2e241aa307fcd44512b8078ccb1
-size 2533755

--- a/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20190102_030000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20190102_030000z.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1836520fe8242a3ac9f1e17ec08e907f28f794dae807b0e20716b8e39e02279b
-size 2533755

--- a/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20190102_060000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20190102_060000z.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce072a9f03a5c698459364a94d1f409d7bdf5c6e35849e792dcd7c13c4ee9f93
-size 2533755

--- a/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20200903_150000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20200903_150000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80fc7009a84ecda84c5b4dac590f396231304c2a827ee8e8288935f8a767ffba
+size 2514132

--- a/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20200903_180000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20200903_180000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49f579f2ba669336d687ceec9f10fedafc36022cf5e3d362cebcc3ada7f77689
+size 2514132

--- a/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20200903_210000z.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.bkg.20200903_210000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d448eab0ad2a250d484361099cae36cf17d89a2df5e0f9dbb74e9301afeb37db
+size 2514132

--- a/testinput_tier_1/inputs/geos_c12/geos.cf.stddev.nox_50_o3_25.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos.cf.stddev.nox_50_o3_25.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:029b98c87054f1df0c0123cd2d1f87ecba3e71fc08318dfee8d8d7bc5ecf7a63
-size 1521598
+oid sha256:e6961c2861474404fef411c2b61743a89a38e59fb93b7c89c2f7ebc6b1d269cf
+size 1495700

--- a/testinput_tier_1/obs/tropomi_no2_2019010200_m.nc4
+++ b/testinput_tier_1/obs/tropomi_no2_2019010200_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0222c0bd3e7c5c2811ebad01b44e7914d1a6a9c5508c66b7ecf64a3cd471bacd
-size 496923

--- a/testinput_tier_1/obs/tropomi_no2_2020090318_m.nc4
+++ b/testinput_tier_1/obs/tropomi_no2_2020090318_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1e90a5a53f41f2e16ef4273679a97f6c428a1293be12942ec56b524121d7d89
-size 262831

--- a/testinput_tier_1/obs/tropomi_no2_total_2020090318_m.nc4
+++ b/testinput_tier_1/obs/tropomi_no2_total_2020090318_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1594277dabb131e5acc093f8565539b2d4f69a188fd7551149f32aa4e847cd7a
+size 249101

--- a/testinput_tier_1/obs/tropomi_no2_total_2020090318_m.nc4
+++ b/testinput_tier_1/obs/tropomi_no2_total_2020090318_m.nc4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1594277dabb131e5acc093f8565539b2d4f69a188fd7551149f32aa4e847cd7a
-size 249101

--- a/testinput_tier_1/obs/tropomi_no2_tropo_2020090318_m.nc4
+++ b/testinput_tier_1/obs/tropomi_no2_tropo_2020090318_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f1582e8810d14fe55f835b41c77eef28de2311dd0538e4a5be5529d0c62992f
+size 244571


### PR DESCRIPTION
Updating data for the new column operator 
https://github.com/JCSDA-internal/fv3-jedi/pull/584
https://github.com/JCSDA-internal/ufo/pull/2228

Tests are now using only one obs file (which is consistent with the tropomi no2 files in ufo-data) to make it easier for updates.