### PR TITLE
Merge release/skylab_v3 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,4 @@
 
 cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
 
-project( fv3_jedi_data VERSION 1.3.0 DESCRIPTION "FV3-JEDI Test Files" )
+project( fv3_jedi_data VERSION 1.4.0 DESCRIPTION "FV3-JEDI Test Files" )


### PR DESCRIPTION
## Description

As the title says. Created separate branch because we want `release/skylab-v3` to stick around until the next release.

## Acceptance Criteria (Definition of Done)

PR merged

## Dependencies

none

## Impact

Release branches need to be merged for all repositories in order for develop to function correctly.