### PR TITLE
rollback changes in VIIRS bias correction file

### DIFF
--- a/testinput_tier_1/obs/VIIRS_bias.nc
+++ b/testinput_tier_1/obs/VIIRS_bias.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7f136c91669c220ad031bfa22e11cd715933ca9ee346c91260db3e326c42ae9
-size 10736
+oid sha256:cf9dfe8776c8c23315c6f212925a19d6d67933d3be915b6df1b6286007b43851
+size 7928


### PR DESCRIPTION
## Description

`fv3jedi_test_tier2_hyb-3dvar_gfs_aero_bump_bc` is failing on develop with the following error:
> 162 - fv3jedi_test_tier2_hyb-3dvar_gfs_aero_bump_bc (Failed)
=> 162: Exception: oops::Variational<FV3JEDI, UFO and IODA observations> terminating...
   162: Exception: 	Reason:	An exception occurred inside ioda while opening a variable.
   162: 	name:	bias_coefficients
   162: 	source_column:	0
   162: 	source_filename:	/home/ubuntu/code/bundle/ioda/src/engines/ioda/src/ioda/Has_Variables.cpp
   162: 	source_function:	virtual ioda::Variable ioda::detail::Has_Variables_Base::open(const string&) const
   162: 	source_line:	108

This missing entry was likely a result of me carelessly applying the ioda-upgrader-v2-v3 to this file (the upgrader didn't need to be applied to bias files). 

This PR rolls back this file to its original version, and with updated test reference `fv3jedi_test_tier2_hyb-3dvar_gfs_aero_bump_bc`  test pass with GNU and Intel compilers on orion.