### PR TITLE
Added a faked observation file for a new ctest for recently fixed lateral boundary halo points 

### DIFF
--- a/testinput_tier_1/obs/aircraft_obs_on_lbc_obs_2020121500_m.nc4
+++ b/testinput_tier_1/obs/aircraft_obs_on_lbc_obs_2020121500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc631a552bf9894fe68779ed6d4f34745247b9c922e7677fd5b8d2d234e27833
+size 25926

--- a/testinput_tier_1/obs/ghcn_snwd_ioda_20230501.nc
+++ b/testinput_tier_1/obs/ghcn_snwd_ioda_20230501.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:308042496557b42114fed330836743275fee42de3a734756ce79d485713e0cdb
-size 372531
+oid sha256:93a0cd1483ecfc1b1877a8e875e60f8b7ba3c697ca6ef5be8b647e87637dafa9
+size 562461


### PR DESCRIPTION
This PR is in complementary to (depends on ) the PR https://github.com/JCSDA-internal/fv3-jedi/pull/1110 to Adding a hofx ctest for the fixed lateral boundary halo points treatments. 
This PR would add a new small-size observation file with the (only) faked observation close to (on ) the lateral boundary). 

