### PR TITLE
Add an empty file (0 obs) for test

### DIFF
--- a/testinput_tier_1/obs/empty_obs_file.nc4
+++ b/testinput_tier_1/obs/empty_obs_file.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e73dc8ffc934e6b07938813f0286e281327570c570ef40992acdf6375b5e7a1
+size 686


### PR DESCRIPTION
## Description

Adds an empty file for testing behavior with 0 obs.

```
ncdump testinput_tier_1/obs/empty_obs_file.nc4 
netcdf empty_obs_file {
dimensions:
	Location = UNLIMITED ; // (0 currently)
}
```