### PR TITLE
VarBC sprint bias variable name update

### DIFF
--- a/testinput_tier_1/obs/satbias_amsua_n19.nc4
+++ b/testinput_tier_1/obs/satbias_amsua_n19.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ef98f03fbd6e39a4d3aaace9a891c153500920c089175aeae1dd72b30f7e059
-size 20149
+oid sha256:178ceee7d3ca873344967843e905e4e4d908f54c0e80dc9e8a6573a9fd499d79
+size 26023


### PR DESCRIPTION



build-group=https://github.com/JCSDA-internal/fv3-jedi/pull/1201
build-group=https://github.com/JCSDA-internal/ioda/pull/1092

## Description

The VarBC-sprint fails some ctests in jedi-integration due to the renaming of bias varibles. This PR will update the names of the bias variable to match that of the VarBC-sprint.

fv3jedi_test_tier1_hyb-3dvar..........................................................failed
fv3jedi_test_tier1_hyb-fgat_fv3lm.....................................................failed
fv3jedi_test_tier1_4denvar............................................................failed
fv3jedi_test_tier1_4denvar_seq........................................................failed


# Issue(s) addressed

Resolves https://github.com/JCSDA-internal/fv3-jedi/issues/1198

Dependencies
Will depend on a fv3-jedi-data PR which will be created.

## Impact

Unknown. Needs to be monitored.


