### PR TITLE
Upgrade `viirs_npp` VarBC files

### DIFF
--- a/testinput_tier_1/obs/VIIRS_bias.nc
+++ b/testinput_tier_1/obs/VIIRS_bias.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf9dfe8776c8c23315c6f212925a19d6d67933d3be915b6df1b6286007b43851
-size 7928

--- a/testinput_tier_1/obs/VIIRS_npp_bias_coeff.nc4
+++ b/testinput_tier_1/obs/VIIRS_npp_bias_coeff.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6959c6c365fa5b79021515313d0af8910252c7d3749082d6ec11da4ad53a8803
-size 7888
+oid sha256:0a6c79fdd8dd1bbaf8d6aeda15ff9c05a8f1b23170d4dbed0b433242e4ed895f
+size 9553

--- a/testinput_tier_1/obs/VIIRS_npp_bias_error.nc4
+++ b/testinput_tier_1/obs/VIIRS_npp_bias_error.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:159cf98f6e3516268b4ab00f030aa076092bc14799b1460933b8760f57d1ec21
-size 8264
+oid sha256:39e02892e5b3e6bbb3a68f0a146dc968ee6573b3d96628d6a9a28d155ce23f0b
+size 9553


### PR DESCRIPTION
## Description
This PR upgrades the `viirs_npp` VarBC files. It also removes one file that is not being used by any other test.

## Issue(s) addressed
Resolves https://github.com/JCSDA-internal/fv3-jedi/issues/1209

## Dependencies
None.

## Impact
None.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
