### PR TITLE
adding lat-lon GEOS ensemble

### DIFF
--- a/testinput_tier_1/inputs/geos_4x5/mem001/f5271_fp.bkg.eta.20201214_2100z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem001/f5271_fp.bkg.eta.20201214_2100z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da1a2c423ca11f6487a204430c14b62eb96d25812063a5252b169e03a3d1aac0
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem001/f5271_fp.bkg.eta.20201215_0000z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem001/f5271_fp.bkg.eta.20201215_0000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa4fc6c1850dde8139c63ccea9b387f617b0a585e01f1dcc3a66c8162e736480
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem001/f5271_fp.bkg.eta.20201215_0300z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem001/f5271_fp.bkg.eta.20201215_0300z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c9a87b4abc54d7537e13273f42e901e4b54553c265c8617582c9dee159b964c
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem002/f5271_fp.bkg.eta.20201214_2100z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem002/f5271_fp.bkg.eta.20201214_2100z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db2c9e59652f0a42157f0940421eae33c824fcea504b94cf158fda1f3eaa975f
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem002/f5271_fp.bkg.eta.20201215_0000z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem002/f5271_fp.bkg.eta.20201215_0000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aa51f04064001db64e531ea5a53dfb0467e091c6bca7ea744b4b92a02b5dd7e
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem002/f5271_fp.bkg.eta.20201215_0300z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem002/f5271_fp.bkg.eta.20201215_0300z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63f2faa0f1017d6930c82794b7c5f58e5de98f53166b9b45b330e7a0f6fb24de
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem003/f5271_fp.bkg.eta.20201214_2100z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem003/f5271_fp.bkg.eta.20201214_2100z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b31ea7157bd56aa3aaae6f7f06d24c05b04ecdcb8bef4ee88101fc7965c87e79
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem003/f5271_fp.bkg.eta.20201215_0000z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem003/f5271_fp.bkg.eta.20201215_0000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9bb25db4136035cd65d4a98f4d0a7f35cb9830e28d738642aad01912d74bbf1
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem003/f5271_fp.bkg.eta.20201215_0300z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem003/f5271_fp.bkg.eta.20201215_0300z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23f1e48995362525c5be6ee0d6ea3fd3a531383099240cb2bc0da965f15de605
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem004/f5271_fp.bkg.eta.20201214_2100z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem004/f5271_fp.bkg.eta.20201214_2100z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bef47bd85613924f1ffadfc0e2c5e3234bbcfddf889007b7eb6d857059d543b
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem004/f5271_fp.bkg.eta.20201215_0000z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem004/f5271_fp.bkg.eta.20201215_0000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b57bab08d1911bcfc62e56a9ac809aa9fcf075f61db29c5f614f3aa8d37d4e2c
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem004/f5271_fp.bkg.eta.20201215_0300z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem004/f5271_fp.bkg.eta.20201215_0300z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ba324da82d427851ac2abea86ebc972712653940f959387e0a34682206d1a68
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem005/f5271_fp.bkg.eta.20201214_2100z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem005/f5271_fp.bkg.eta.20201214_2100z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b77ef6477dbcd820121ee9e28d76e379ab4d2b79b7e219fb98991f219a45ff74
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem005/f5271_fp.bkg.eta.20201215_0000z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem005/f5271_fp.bkg.eta.20201215_0000z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e16dd376a836528f165117a8fdb50f08a3b4aa651bb34f1e58a96efb3e717bc
+size 9877259

--- a/testinput_tier_1/inputs/geos_4x5/mem005/f5271_fp.bkg.eta.20201215_0300z.nc4
+++ b/testinput_tier_1/inputs/geos_4x5/mem005/f5271_fp.bkg.eta.20201215_0300z.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34a4efb8920949bf7486a70ddaf1793460c823abcaa67d43660820326a7ad491
+size 9877259


### PR DESCRIPTION
## Description

This add an small ensemble (5-member) of 3-hourly lat-lon fields to allow testing a fully GSIBEC-controlled hyb 4DEnVar  configuration of fv3-jedi.

## Issue(s) addressed

No issue has been filed on these.

## Dependencies

List the other PRs that this PR is dependent on:

- https://github.com/JCSDA-internal/fv3-jedi/pull/1225.

## Impact

Adding these should not affect anything and it should enable the PR in fv3-jedi pointed to above.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
