### PR TITLE
split obs

### DIFF
--- a/testinput_tier_1/obs/obsappend1/aircraft_obs_2020121500_m_renamed_var.nc4
+++ b/testinput_tier_1/obs/obsappend1/aircraft_obs_2020121500_m_renamed_var.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77c348efb2f733522e1f49a7caee0b9a22e2447a02d3b15056263fdb71b2c278
+size 298430

--- a/testinput_tier_1/obs/obsappend2/aircraft_obs_2020121500_m_renamed_var.nc4
+++ b/testinput_tier_1/obs/obsappend2/aircraft_obs_2020121500_m_renamed_var.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b27c3e509433b083c589045028942c7d1ecd4effb59774dde111647c6fcfa2c0
+size 306997


### PR DESCRIPTION
## Description

build-group= https://github.com/JCSDA-internal/fv3-jedi/pull/1248
build-group=https://github.com/JCSDA-internal/oops/pull/2733
build-group=https://github.com/JCSDA-internal/ioda/pull/1324

This PR adds split observations for use in a ctest that exercises the append functionality between outer loops.  

## Issue(s) addressed

Resolves #2731

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] https://github.com/JCSDA-internal/fv3-jedi/pull/1248
- [ ] https://github.com/JCSDA-internal/oops/pull/2733
- [ ] https://github.com/JCSDA-internal/ioda/pull/1324

## Impact

Expected impact on downstream repositories:

## Checklist

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x ] I have run the unit tests before creating the PR
