### PR TITLE
obs now split by time

### DIFF
--- a/testinput_tier_1/obs/obsappend1/aircraft_obs_2020121500_m_renamed_var.nc4
+++ b/testinput_tier_1/obs/obsappend1/aircraft_obs_2020121500_m_renamed_var.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77c348efb2f733522e1f49a7caee0b9a22e2447a02d3b15056263fdb71b2c278
-size 298430
+oid sha256:da61fc74f3c24ed3dbffcad1674b1eea096d96324028dbb40b1272bf311ad7a8
+size 469294

--- a/testinput_tier_1/obs/obsappend2/aircraft_obs_2020121500_m_renamed_var.nc4
+++ b/testinput_tier_1/obs/obsappend2/aircraft_obs_2020121500_m_renamed_var.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b27c3e509433b083c589045028942c7d1ecd4effb59774dde111647c6fcfa2c0
-size 306997
+oid sha256:37667b1248db7270e1429e24d77a66fdfae86def438edf0781b57fd1afe89f4a
+size 424642


### PR DESCRIPTION
## Description

Previously the data needed for the append obs ctest in fv3-jedi was split by location, it is now split by time to also enable testing of the shifting of the end of the DA window. 

build-group=JCSDA-internal/oops#2802
build-group=JCSDA-internal/ioda#1400
build-group=JCSDA-internal/fv3-jedi#1325
build-group=JCSDA-internal/fv3-jedi-data#104
build-group=JCSDA-internal/mpas-jedi#1033
build-group=JCSDA-internal/mpas-jedi-data#9

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:
-  [ ]  JCADA-internal/oops#2802
- [ ]  JCSDA-internal/ioda#1400
- [ ]  JCSDA-internal/fv3-jedi#1325
- [ ]  JCSDA-internal/fv3-jedi-data#104
- [ ]  JCSDA-internal/mpas-jedi#1033
- [ ]  JCSDA-internal/mpas-jedi-data#9

## Impact

Expected impact on downstream repositories:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have run the unit tests before creating the PR
