### PR TITLE
Add lat/lon to GEOS CF Standard Dev File

### DIFF
--- a/testinput_tier_1/inputs/geos_c12/geos_cf.stddev.nox_50_o3_25.nc4
+++ b/testinput_tier_1/inputs/geos_c12/geos_cf.stddev.nox_50_o3_25.nc4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcd3de4143c0b921efbe2adb8748e089730a42f6f4f23e899cf1d7e946123a0e
-size 1495700
+oid sha256:746e58bc94e8b7eb7aa524e1e428801c0fa44f9e62d849d1257a0567b61de7e7
+size 1510224


### PR DESCRIPTION
## Description

Add the lat and lon variables to the GEOS CF standard deviation file, which is missing them.

Required for a downstream PR,