### PR TITLE
Remove Git LFS from the fv3-jedi repo

### DIFF
--- a/testinput_tier_1/inputs/femps/fv3grid_c0006.nc4
+++ b/testinput_tier_1/inputs/femps/fv3grid_c0006.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78334e6054aac707d9a7d36fd827e3a988275ed6c675e604e705ed8dab959e05
+size 22512

--- a/testinput_tier_1/inputs/femps/fv3grid_c0012.nc4
+++ b/testinput_tier_1/inputs/femps/fv3grid_c0012.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac31a9912784f16ce8cd62c87712e357170c3cc7221a751a1ad2205be816d74c
+size 46128

--- a/testinput_tier_1/inputs/femps/fv3grid_c0024.nc4
+++ b/testinput_tier_1/inputs/femps/fv3grid_c0024.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6602098dc4ff40a5482b717d20fa64d204a41ed4b03ee47121e7416fb19753d
+size 131376

--- a/testinput_tier_1/inputs/femps/fv3grid_c0048.nc4
+++ b/testinput_tier_1/inputs/femps/fv3grid_c0048.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9f0b9c8695c6c19e50b33d6ea44520dc7eba5653e25d9b0758df77bf2bd9134
+size 467760

--- a/testinput_tier_1/inputs/femps/fv3grid_c0096.nc4
+++ b/testinput_tier_1/inputs/femps/fv3grid_c0096.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0532c56b7fb2df40b8caa01e30e9ea368aecd016a911c01f815f791f1fcb8e
+size 1804080

--- a/testinput_tier_1/inputs/fv3files/akbk127.nc4
+++ b/testinput_tier_1/inputs/fv3files/akbk127.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cd014ca6e73386f0adc6b144261fcef5f9639b4678fd598b113e5180cf176b7
+size 8406

--- a/testinput_tier_1/inputs/fv3files/akbk64.nc4
+++ b/testinput_tier_1/inputs/fv3files/akbk64.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9fbc8ce39d60d5eee88f821d4c011e2af242470ab579aeca90b2374cff95d0b
+size 17816

--- a/testinput_tier_1/inputs/fv3files/akbk72.nc4
+++ b/testinput_tier_1/inputs/fv3files/akbk72.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9730a2467b4c4c4ea2c5af1a2f97363db69b7238ab987167b50633bc97c057b1
+size 11541


### PR DESCRIPTION
## Description

Move the files that require Git LFS into the fv3-jedi-data repo.

## Dependencies

None

## Impact

None, until changes are also made to fv3-jedi. But this can be merged regardless of any changes there.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
