### PR TITLE
Illustrative PR: help to show error when running LGETKF linear observer with "variational bc"

### DIFF
--- a/testinput_tier_1/obs/amsua_n19_obs_2020121500_l.nc4
+++ b/testinput_tier_1/obs/amsua_n19_obs_2020121500_l.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89f06b1cad959a6edd52843fd61169e874a25f12d73a151948e2b982b8ed51e5
+size 13937277


### PR DESCRIPTION
## Description

Add amsua_n19_obs_2020121500_l.nc4  (14 M.) to illustrate error when running LGETKF-Linear with variational bc.
- Location = UNLIMITED ; // (9264 currently)

The median sized file amsua_n19_obs_2020121500_m.nc4  contains only 
- Location = 100 ;
which fails to reproduce the error. 

## Issue(s) addressed

## Dependencies

## Impact

File size:  14 M.  

## Manual Testing Instructions (optional)


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
