### PR TITLE
Update lam_rrfs test data from 64-bit offset to netCDF-4

### DIFF
--- a/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.fv_core.res.tile1.nc
+++ b/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.fv_core.res.tile1.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85eed920016f7d670c2d583682ead2bed73062901eb4cb12c47ff862aa29ff2a
-size 66408392
+oid sha256:2c76b67eb13f71e50ae58ff82ff1fc4e1898eec7ccf3f0df77573cac44b810f9
+size 66438889

--- a/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.fv_srf_wnd.res.tile1.nc
+++ b/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.fv_srf_wnd.res.tile1.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d07f7414fd78f3fd653210144accd3b2303ceb498838977937cab210d56f84e
-size 357516
+oid sha256:caa5fd20c1561a9ef767f5fd4588a8bd1b8f8af1780e3a9ddc6235af889ceb83
+size 364945

--- a/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.fv_tracer.res.tile1.nc
+++ b/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.fv_tracer.res.tile1.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e8e55bc8bf537e743043ad65071ab4f18898ad3f75140bf0cce467eef9fc39a
-size 131717228
+oid sha256:f7d7c6874c057a1b35fd4a77931fa9955a97c6affcd6fbcb6ef932c4cc45ab4e
+size 131767270

--- a/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.sfc_data.nc
+++ b/testinput_tier_1/inputs/lam_rrfs/bkg/20201215.000000.rrfs_C403.sfc_data.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37ea482f862425ed42aeb0022e812218feff49f0fc306905ae701b59e41f37ee
-size 4749092
+oid sha256:4a4c8de93fe94e9b1d7abee3bc59ee35fb0fb43b3dbe95b2103a44533e60fdad
+size 4798926


### PR DESCRIPTION
## Description

This PR updates the lam_rrfs test data from 64-bit offset format to netCDF-4. This allows us to test the new, non-fms read path introduced in https://github.com/JCSDA-internal/fv3-jedi/pull/1514. 

This new read path opens restart files with `nf90_open(..., NF90_MPIIO, comm=...)` for collective reads. Parallel access requires either the files to be in netCDF-4 format or for the netCDF4-C library to be built with PnetCDF support (which spack-stack apparently does not use). 

Here is the new format. The output for nccmp below shows that the only difference between the two files is their format and not the data values.  

```
[Samuel.Degelia@ufe02 bkg]$ ncdump -k 20201215.000000.rrfs_C403.fv_core.res.tile1.nc
netCDF-4 classic model
[Samuel.Degelia@ufe02 bkg]$ nccmp -dms 20201215.000000.rrfs_C403.fv_core.res.tile1.nc orig/20201215.000000.rrfs_C403.fv_core.res.tile1.nc
DIFFER : FILE FORMATS : NC_FORMAT_NETCDF4_CLASSIC <> NC_FORMAT_64BIT
```



## Issue(s) addressed

None

## Dependencies

None

## Impact

None, all fv3-jedi tests with the updated formats still pass. 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
